### PR TITLE
Fix broken source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# vite-plugin-flow
-
-Support [Flow static type checking](https://flow.org/) in [Vite](https://vitejs.dev/)
 
 ## Install
 
@@ -48,7 +45,7 @@ Create a Vite plugin object
 
 #### Parameters
 
-*   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Filter options (optional, default `{include:/\.(flow|jsx?)$/,exclude:/node_modules/,flow:{all:false,pretty:true,ignoreUninitializedFields:false}}`)
+*   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Filter options (optional, default `{include:/\.(flow|jsx?)$/,exclude:/node_modules/,flow:{all:false,pretty:false,ignoreUninitializedFields:false}}`)
 
     *   `options.include` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Regexp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Regexp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp))>)** Strings and/or regular expressions matching file paths to include (optional, default `/\.(flow|jsx?)$/`)
     *   `options.exclude` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Regexp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Regexp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp))>)** Strings and/or regular expressions matching file paths to exclude (optional, default `/node_modules/`)
@@ -65,10 +62,10 @@ Create an esbuild plugin object
 
 *   `filter` **[RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)** Regular expression matching the path a files to be processed (optional, default `/\.(flow|jsx?)$/`)
 *   `loaderFunction` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Function that accepts the file path and returns the esbuild loader type (optional, default `(path)=>(/\.jsx$/.test(path)?'jsx':'js')`)
-*   `flowOptions` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options to pass to flow-remove-types (optional, default `{all:false,pretty:true,ignoreUninitializedFields:false}`)
+*   `flowOptions` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options to pass to flow-remove-types (optional, default `{all:false,pretty:false,ignoreUninitializedFields:false}`)
 
     *   `flowOptions.all` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, bypasses looking for an @flow pragma comment before parsing. (optional, default `false`)
-    *   `flowOptions.pretty` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, removes types completely rather than replacing with spaces. (optional, default `true`)
+    *   `flowOptions.pretty` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, removes types completely rather than replacing with spaces. (optional, default `false`)
     *   `flowOptions.ignoreUninitializedFields` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, removes uninitialized class fields (`foo;`, `foo: string;`)
         completely rather than only removing the type. THIS IS NOT SPEC
         COMPLIANT! Instead, use `declare foo: string;` for type-only fields. (optional, default `false`)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# vite-plugin-flow
+
+Support [Flow static type checking](https://flow.org/) in [Vite](https://vitejs.dev/)
 
 ## Install
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ type EsbuildPlugin = {
  * @param {string | Regexp | Array<string | Regexp>} [options.include=/\.(flow|jsx?)$/] - Strings and/or regular expressions matching file paths to include
  * @param {string | Regexp | Array<string | Regexp>} [options.exclude=/node_modules/] - Strings and/or regular expressions matching file paths to exclude
  * @param {boolean} [options.flow.all=false] - If true, bypasses looking for an @flow pragma comment before parsing.
- * @param {boolean} [options.flow.pretty=true] - If true, removes types completely rather than replacing with spaces.
+ * @param {boolean} [options.flow.pretty=false] - If true, removes types completely rather than replacing with spaces.
  * @param {boolean} [options.flow.ignoreUninitializedFields=false] - If true, removes uninitialized class fields (`foo;`, `foo: string;`)
  *     completely rather than only removing the type. THIS IS NOT SPEC
  *     COMPLIANT! Instead, use `declare foo: string;` for type-only fields.
@@ -78,7 +78,7 @@ module.exports.flowPlugin = function flowPlugin(options: VitePluginOptions = {
   exclude: /node_modules/,
   flow: {
     all: false,
-    pretty: true,
+    pretty: false,
     ignoreUninitializedFields: false,
   },
 }): VitePlugin {
@@ -91,7 +91,7 @@ module.exports.flowPlugin = function flowPlugin(options: VitePluginOptions = {
         const transformed = flowRemoveTypes(src, options.flow);
         return {
           code: transformed.toString(),
-          map: transformed.generateMap(),
+          map: null,
         };
       }
     },
@@ -109,7 +109,7 @@ const defaultloaderFunction = (path: string) => (jsxRegex.test(path) ? 'jsx' : '
  * @param {Function} [loaderFunction=(path) => (/\.jsx$/.test(path) ? 'jsx' : 'js')] Function that accepts the file path and returns the esbuild loader type
  * @param {Object} flowOptions - Options to pass to flow-remove-types
  * @param {boolean} [flowOptions.all=false] - If true, bypasses looking for an @flow pragma comment before parsing.
- * @param {boolean} [flowOptions.pretty=true] - If true, removes types completely rather than replacing with spaces.
+ * @param {boolean} [flowOptions.pretty=false] - If true, removes types completely rather than replacing with spaces.
  * @param {boolean} [flowOptions.ignoreUninitializedFields=false] - If true, removes uninitialized class fields (`foo;`, `foo: string;`)
  *     completely rather than only removing the type. THIS IS NOT SPEC
  *     COMPLIANT! Instead, use `declare foo: string;` for type-only fields.
@@ -123,7 +123,7 @@ module.exports.esbuildFlowPlugin = function esbuildFlowPlugin(filter: RegExp = /
   ignoreUninitializedFields: boolean,
 } = {
   all: false,
-  pretty: true,
+  pretty: false,
   ignoreUninitializedFields: false,
 }): EsbuildPlugin {
   return {


### PR DESCRIPTION
Fixes https://github.com/bunchtogether/vite-plugin-flow/issues/4#

Source maps now work by default in Vite with this plugin.

There's a related issue here:
https://github.com/leebyron/rollup-plugin-flow/issues/5

And some fixes in other codebases:
https://github.com/styled-components/styled-components/pull/3597/files
https://github.com/openstreetmap/iD/pull/4885/files
https://github.com/mapbox/mapbox-gl-js/blob/main/build/rollup_plugins.js#L41-L51

The key point is that if the transform doesn't change the source, then we should return `null` here:
https://github.com/bunchtogether/vite-plugin-flow/blob/e0b11cce7a3c8e7a27975b677269ab64a039b37b/src/index.js#L94

Note that `pretty` is currently defaulted to `true`, which is the opposite of the actual https://github.com/facebook/flow/tree/main/packages/flow-remove-types package. With pretty `true`, then transforms do change the source, and the source maps break. This PR switches it to `false`, as I don't know how to get source maps working by default otherwise. I'm not sure if this is considered a breaking change.